### PR TITLE
epicenter-1564 markdown compatibility fixes (template and generated docs)

### DIFF
--- a/documentation/template.ejs
+++ b/documentation/template.ejs
@@ -18,13 +18,13 @@
     <? doc.javadoc.forEach(function (block) { ?>
         <? if (!block.paramStr && (block.returnTags.length == 0)) { ?>
             <? if (configStart === 0) { ?>
-                ##Configuration Options
+                ## Configuration Options
 
                 <? configStart = 1 ?>
             <? } ?>
             <? var configOption =  block.raw.code.split(':')[0] ?>
 
-            ###<?= configOption ?>
+            ### <?= configOption ?>
 
             <? block.raw.tags.forEach(function (tag) { ?>
                 <? if (tag.type === 'type') { ?>
@@ -45,7 +45,7 @@
     <? doc.javadoc.forEach(function (block) { ?>
         <? if (block.paramStr || (block.returnTags.length > 0)) { ?>
             <? if (methodStart === 0) { ?>
-                ##Methods
+                ## Methods
 
                 <? methodStart = 1 ?>
             <? } ?>
@@ -57,7 +57,7 @@
                 }
             ?>
 
-            ###<?= methodName ?>
+            ### <?= methodName ?>
             <?= block.description ?>
 
             <? var paramStart = 0 ?>

--- a/src/dom/attributes/binds/default-bind-attr.js
+++ b/src/dom/attributes/binds/default-bind-attr.js
@@ -3,7 +3,7 @@
  *
  * The most commonly used attribute provided by Flow.js is the `data-f-bind` attribute.
  *
- * ####data-f-bind with a single value
+ * #### data-f-bind with a single value
  *
  * You can bind variables from the model in your interface by setting the `data-f-bind` attribute. This attribute binding is bi-directional, meaning that as the model changes, the interface is automatically updated; and when users change values in the interface, the model is automatically updated. Specifically:
  *
@@ -31,7 +31,7 @@
  * * Remember that if your model is in Vensim, the time step can be the first array index or the last array index, depending on your [model.cfg](../../../../../../model_code/vensim/#creating-cfg) file.
  * * By default, all HTML elements update for any change for each variable. However, you can prevent the user interface from updating &mdash; either for all variables or for particular variables &mdash; by setting the `silent` property when you initialize Flow.js. See more on [additional options for the Flow.initialize() method](../../../../../#custom-initialize).
  *
- * ####data-f-bind with multiple values and templates
+ * #### data-f-bind with multiple values and templates
  *
  * If you have multiple variables, you can use the shortcut of listing multiple variables in an enclosing HTML element and then referencing each variable using templates. (Templates are available as part of Flow.js's lodash dependency. See more background on [working with templates](../../../../../#templates).)
  *

--- a/src/dom/attributes/events/default-event-attr.js
+++ b/src/dom/attributes/events/default-event-attr.js
@@ -1,9 +1,9 @@
 /**
- * ##Call Operation in Response to User Action
+ * ## Call Operation in Response to User Action
  *
  * Many models call particular operations in response to end user actions, such as clicking a button or submitting a form.
  *
- * ####data-f-on-event
+ * #### data-f-on-event
  *
  * For any HTML attribute using `on` -- typically on click or on submit -- you can add the attribute `data-f-on-XXX`, and set the value to the name of the operation. To call multiple operations, use the `|` (pipe) character to chain operations. Operations are called serially, in the order listed.
  *

--- a/src/dom/attributes/events/init-event-attr.js
+++ b/src/dom/attributes/events/init-event-attr.js
@@ -1,9 +1,9 @@
 /**
- * ##Call Operation when Element Added to DOM
+ * ## Call Operation when Element Added to DOM
  *
  * Many models call an initialization operation when the [run](../../../../../../glossary/#run) is first created. This is particularly common with [Vensim](../../../../../../model_code/vensim/) models, which need to initialize variables ('startGame') before stepping. You can use the `data-f-on-init` attribute to call an operation from the model when a particular element is added to the DOM.
  *
- * ####data-f-on-init
+ * #### data-f-on-init
  *
  * Add the attribute `data-f-on-init`, and set the value to the name of the operation. To call multiple operations, use the `|` (pipe) character to chain operations. Operations are called serially, in the order listed. Typically you add this attribute to the `<body>` element.
  *

--- a/src/flow.js
+++ b/src/flow.js
@@ -5,7 +5,7 @@
  *
  * However, sometimes you want to be explicit in your initialization call, and there are also some additional parameters that let you customize your use of Flow.js.
  *
- * ####Parameters
+ * #### Parameters
  *
  * The parameters for initializing Flow.js include:
  *
@@ -37,7 +37,7 @@
  *
  * The `Flow.initialize()` call is based on the Epicenter.js [Run Service](../../../api_adapters/generated/run-api-service/) from the [API Adapters](../../../api_adapters/). See those pages for additional information on parameters.
  *
- * ####Example
+ * #### Example
  *
  *      Flow.initialize({
  *          channel: {


### PR DESCRIPTION
now that the build servers use an upgraded version of everything, we're seeing some problems in markdown / docpad. first pass at fixing.

(see also https://github.com/forio/epicenter/compare/doc-build-fix3)