### PR TITLE
epicenter-1361 vensim time step is the last index when accessing an array

### DIFF
--- a/src/dom/attributes/binds/default-bind-attr.js
+++ b/src/dom/attributes/binds/default-bind-attr.js
@@ -28,7 +28,7 @@
  *
  * * Use square brackets, `[]`, to reference arrayed variables: `sales[West]`.
  * * Use angle brackets, `<>`, to reference other variables in your array index: `sales[<currentRegion>]`.
- * * Remember that if your model is in Vensim, the time step can be the first array index or the last array index, depending on your [model.cfg](../../../../../../model_code/vensim/#creating-cfg) file.
+ * * Remember that if your model is in Vensim, the time step is the last array index.
  * * By default, all HTML elements update for any change for each variable. However, you can prevent the user interface from updating &mdash; either for all variables or for particular variables &mdash; by setting the `silent` property when you initialize Flow.js. See more on [additional options for the Flow.initialize() method](../../../../../#custom-initialize).
  *
  * #### data-f-bind with multiple values and templates


### PR DESCRIPTION
background: you can set this in your model.cfg file, but we checked and no one did. the new version, model.ctx, does not allow you to set this. update the docs to just say that it’s the last index.

not urgent to get this into a tagged version, just want to keep the source in sync with epicenter/docs/public. 