### PR TITLE
TEMPLATE-474 added variable filter to prevent retrying bad variables

### DIFF
--- a/src/channels/route-handlers/epicenter-route-handlers/run-route-handler/run-variables-route-handler/retriable-variable-fetch.js
+++ b/src/channels/route-handlers/epicenter-route-handlers/run-route-handler/run-variables-route-handler/retriable-variable-fetch.js
@@ -1,17 +1,62 @@
+function hasValidBrackets(variable) {
+    const brackets = {
+        '[': 0,
+        '{': 0,
+        '(': 0,
+        '<': 0,
+    };
+    let isValid = true;
+    for (let i = 0; i < variable.length; i++) {
+        const char = variable[i];
+        if ('[{(<'.indexOf(char) >= 0) {
+            // Opening bracket
+            brackets[char] = brackets[char] + 1;
+        } else if (']})>'.indexOf(char) >= 0) {
+            // Closing bracket
+            let correspondingChar;
+            switch (char) {
+                case ']':
+                    correspondingChar = '[';
+                    break;
+                case '}':
+                    correspondingChar = '{';
+                    break;
+                case ')':
+                    correspondingChar = '(';
+                    break;
+                case '>':
+                    correspondingChar = '<';
+                    break;
+                default:
+                    break;
+            }
+            if (brackets[correspondingChar] === 0) {
+                isValid = false;
+                break; // Break loop if there is a closing bracket before an opening bracket
+            } else {
+                brackets[correspondingChar] = brackets[correspondingChar] - 1;
+            }
+        }
+    }
+    isValid = isValid && Object.keys(brackets).reduce((acc, key)=> acc + brackets[key], 0) === 0;
+    return isValid;
+}
+
 //Opaquely handle missing variables
 export function retriableFetch(runService, variables) {
     if (!variables || !variables.length) {
         return $.Deferred().resolve({}).promise();
     }
-    return runService.variables().query(variables).catch((e)=> {
+    const validVariables = variables.filter((v)=> hasValidBrackets(v));
+    return runService.variables().query(validVariables).catch((e)=> {
         const response = e.responseJSON;
         const info = response.information;
         if (info.code !== 'VARIABLE_NOT_FOUND') {
             throw e;
         }
+
         const goodVariables = variables.filter((vName)=> {
-            const baseName = vName.split('[')[0];
-            const isBad = info.context.names.indexOf(baseName) !== -1;
+            const isBad = info.context.names.indexOf(vName) !== -1;
             return !isBad;
         });
         return retriableFetch(runService, goodVariables);


### PR DESCRIPTION
I have seen this issue pop up only when working with Data that has Brackets, specifically missing or incomplete brackets. 
The code was originally meant to filter out bad variables and make a call again with good variables but it didn't handle variables with brackets too well.
To fix this, I check for valid brackets and filter accordingly.